### PR TITLE
Added simple but complete kubernetes manifest as an example for kees-init

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+jdk: openjdk8
 script:
   - ./gradlew build shadow
   - docker build . -t bsycorp/kees/init:test -f docker/Dockerfile.init

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-./gradlew clean build shadow bintrayUpload -PappVersion=$TRAVIS_BRANCH
+./gradlew clean build shadow bintrayUpload -PappVersion="$TRAVIS_BRANCH"
 ./gradlew clean build shadow
-docker build . -t bsycorp/kees-init:$TRAVIS_BRANCH -f docker/Dockerfile.init
-docker build . -t bsycorp/kees-creator:$TRAVIS_BRANCH -f docker/Dockerfile.creator
-docker login -u $DOCKERUSER -p $DOCKERPASS
+docker build . -t bsycorp/kees-init:"$TRAVIS_BRANCH" -f docker/Dockerfile.init
+docker build . -t bsycorp/kees-creator:"$TRAVIS_BRANCH" -f docker/Dockerfile.creator
+docker login -u "$DOCKERUSER" -p "$DOCKERPASS"
 docker push bsycorp/kees-init
 docker push bsycorp/kees-creator

--- a/examples/init-example.yaml
+++ b/examples/init-example.yaml
@@ -1,0 +1,62 @@
+# A simple example demonstrating many different types of secrets/resources generation, and then accessing them
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: kees-example
+spec:
+  completions: 1
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      annotations:
+        init.bsycorp.com/local-mode: "true" # Use local values instead of fetching from dynamoDB
+        # REFERENCE expects the secret to have already been inserted in the data store.
+        # It will error if not found.  For local mode we can provide a specific value that will be used.
+        secret.bsycorp.com/reference-password: "kind=REFERENCE,type=PASSWORD,localModeValue=cGFzc3dvcmQK" # local is 'password'
+        secret.bsycorp.com/dynamic-password: "kind=DYNAMIC,type=PASSWORD,size=128" # A password will be generated for us
+        # type RANDOM will result in a base64 encoded blob of random bytes.
+        secret.bsycorp.com/dynamic-random: "kind=DYNAMIC,type=RANDOM,size=128"
+        # type RSA can generate an rsa keypair
+        secret.bsycorp.com/rsa.v1_public: "kind=DYNAMIC,type=RSA,size=2048"
+        secret.bsycorp.com/rsa.v1_private: "kind=DYNAMIC,type=RSA,size=2048"
+        # type GPG can generate a password protected gpg keypair
+        secret.bsycorp.com/gpg.v1_private: "kind=DYNAMIC,type=GPG,size=2048,userId=user<user@email.com>"
+        secret.bsycorp.com/gpg.v1_public: "kind=DYNAMIC,type=GPG,size=2048,userId=user<user@email.com>"
+        secret.bsycorp.com/gpg.v1_password: "kind=DYNAMIC,type=GPG,size=2048,userId=user<user@email.com>"
+        # Resources are more general and can be used to store general configuration that may be dynamic or not known
+        # ahead of time.  For example if a database is provisioned as part of a deployment, its url can be placed
+        # into DynamoDB or SSM in a well known location.  The application can then just refer to this resource.  Now
+        # you no longer need to have per-environment URLs configured and your application will automagically get the
+        # right one when it starts up.
+        resource.bsycorp.com/db-url: "storageKey=db.url,localModeValue=bG9jYWxob3N0OjU0MzIK"
+    spec:
+      restartPolicy: Never
+      initContainers:
+        - name: kees-init
+          image: bsycorp/kees-init:0.1.5
+          volumeMounts:
+            - mountPath: /podinfo
+              name: podinfo-volume
+            - mountPath: /bsycorp-init
+              name: init-volume
+          env:
+            # DDB table name is built using this label.  "<label>-kube-secret".  Required even for local-mode
+            - name: ENV_LABEL
+              value: local
+      containers:
+        - name: kees-consumer
+          image: alpine
+          command: ["cat", "/init/secrets.properties", "/init/resources.properties"]
+          volumeMounts:
+            - mountPath: /init
+              readOnly: true
+              name: init-volume
+      volumes:
+        - name: init-volume
+          emptyDir: {}
+        - name: podinfo-volume
+          downwardAPI:
+            items:
+              - path: annotations
+                fieldRef:
+                  fieldPath: metadata.annotations

--- a/src/main/java/com/bsycorp/kees/CreateMain.java
+++ b/src/main/java/com/bsycorp/kees/CreateMain.java
@@ -38,7 +38,7 @@ public class CreateMain {
     private AtomicInteger exceptionCounter = new AtomicInteger();
     private AtomicInteger eventCounter = new AtomicInteger();
 
-    private Map<String, String> expiryingCache = new PassiveExpiringMap<>(60000);
+    private Map<String, String> expiringCache = new PassiveExpiringMap<>(60000);
 
     public static void main(String... argv) throws Exception {
         CreateMain main = new CreateMain();
@@ -49,7 +49,7 @@ public class CreateMain {
         }
 
         try {
-            main.setStorageProvider(new DynamoDBStorageProvider(Utils.getTableName(Utils.getEnvironment().get("ENV_LABEL"))));
+            main.setStorageProvider(new DynamoDBStorageProvider(Utils.getTableName(envLabel)));
             main.run();
         } catch (Exception e) {
             LOG.error("Error in execution", e);
@@ -99,7 +99,7 @@ public class CreateMain {
                             for (Parameter parameter : parameters) {
                                 try {
                                     //if we have processed this param recently then skip!
-                                    if (expiryingCache.containsKey(parameter.getParameterNameWithField())) {
+                                    if (expiringCache.containsKey(parameter.getParameterNameWithField())) {
                                         LOG.info("Skipping parameter {} as already exists in processed cache..", parameter.getParameterName());
                                         continue;
                                     }
@@ -142,7 +142,7 @@ public class CreateMain {
                                                 }
 
                                                 LOG.info("Created value for {}", parameter.getParameterName());
-                                                expiryingCache.put(parameter.getParameterNameWithField(), "success");
+                                                expiringCache.put(parameter.getParameterNameWithField(), "success");
                                             }
 
                                         } else if (parameter instanceof ResourceParameter) {


### PR DESCRIPTION
Adds an 'examples' directory to place some examples in to help new users quickly understand how this can be used in practice.

To start with only showing the init container with a simple 'Job' resource.