### PR TITLE
Use the right path to cacerts.

### DIFF
--- a/docker/certs.sh
+++ b/docker/certs.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 mkdir -p /etc/ssl/certs
 echo "" > /etc/ssl/certs/dummy-instance.pem
-java -jar keyutil.jar -e /etc/ssl/certs/*instance*.pem -F -f $JAVA_HOME/lib/security/cacerts -i -p changeit -d
+java -jar keyutil.jar -e /etc/ssl/certs/*instance*.pem -F -f $JAVA_HOME/jre/lib/security/cacerts -i -p changeit -d
 exec $@


### PR DESCRIPTION
Fix:

```
Exception in thread "main" java.io.FileNotFoundException: /opt/bitnami/java/lib/security/cacerts (No such file or d
irectory)
        at java.io.FileInputStream.open0(Native Method)
        at java.io.FileInputStream.open(FileInputStream.java:195)
        at java.io.FileInputStream.<init>(FileInputStream.java:138)
        at uk.co.mccnet.keyutil.JKSKeyStoreUtil.<init>(JKSKeyStoreUtil.java:72)
        at uk.co.mccnet.keyutil.Main.main(Main.java:125)
```