### PR TITLE
Adds support for JAVA_OPTS which get added to native image command-line.

### DIFF
--- a/create/Dockerfile.native
+++ b/create/Dockerfile.native
@@ -1,4 +1,5 @@
 FROM bitnami/minideb:stretch
+ENV JAVA_OPTS=""
 ADD build/graal/kees-create-linux-x86_64 /kees-create
 RUN chmod +x /kees-create
-CMD ["/kees-create"]
+CMD exec /kees-create $JAVA_OPTS

--- a/init/Dockerfile
+++ b/init/Dockerfile
@@ -1,4 +1,5 @@
 FROM bitnami/minideb:stretch
+ENV JAVA_OPTS=""
 ADD build/graal/kees-init-linux-x86_64 /kees-init
 RUN chmod +x /kees-init
-CMD ["/kees-init"]
+CMD exec /kees-init $JAVA_OPTS


### PR DESCRIPTION
So in terms of approach we could ask container users to supply their own command-line, this feels like it allows a tiny bit more freedom to change things (e.g. path to binary, additional command-line args) without breaking consumers.