### PR TITLE
Enable a java version of kees-init

### DIFF
--- a/create/Dockerfile
+++ b/create/Dockerfile
@@ -1,3 +1,4 @@
 FROM bitnami/java:1.8-prod
+ENV JAVA_OPTS=""
 ADD build/distributions/create.tar /app/
 CMD ["/app/create/bin/create"]

--- a/deploy.sh
+++ b/deploy.sh
@@ -8,6 +8,8 @@ fi
 ./gradlew nativeImage -i -PappVersion="$TRAVIS_BRANCH" --stacktrace
 ./gradlew distTar -i --stacktrace
 (cd create; docker build . -t bsycorp/kees-creator:"$TRAVIS_BRANCH")
-docker push bsycorp/kees-creator:$TRAVIS_BRANCH
-(cd init; docker build . -t bsycorp/kees-init:"$TRAVIS_BRANCH")
-docker push bsycorp/kees-init:$TRAVIS_BRANCH
+docker push bsycorp/kees-creator:"$TRAVIS_BRANCH"
+(cd init; docker build . -f Dockerfile.native -t bsycorp/kees-init:"$TRAVIS_BRANCH")
+docker push bsycorp/kees-init:"$TRAVIS_BRANCH"
+(cd init; docker build . -t bsycorp/kees-init:"${TRAVIS_BRANCH}-java")
+docker push bsycorp/kees-init:"${TRAVIS_BRANCH}-java"

--- a/deploy.sh
+++ b/deploy.sh
@@ -7,8 +7,9 @@ fi
 ./gradlew build publish -i -PappVersion="$TRAVIS_BRANCH" --stacktrace
 ./gradlew nativeImage -i -PappVersion="$TRAVIS_BRANCH" --stacktrace
 ./gradlew distTar -i --stacktrace
-(cd create; docker build . -t bsycorp/kees-creator:"$TRAVIS_BRANCH")
+(cd create; docker build . -t bsycorp/kees-creator:"$TRAVIS_BRANCH" -t bsycorp/kees-creator:"${TRAVIS_BRANCH}-java")
 docker push bsycorp/kees-creator:"$TRAVIS_BRANCH"
+docker push bsycorp/kees-creator:"${TRAVIS_BRANCH}-java"
 (cd init; docker build . -f Dockerfile.native -t bsycorp/kees-init:"$TRAVIS_BRANCH")
 docker push bsycorp/kees-init:"$TRAVIS_BRANCH"
 (cd init; docker build . -t bsycorp/kees-init:"${TRAVIS_BRANCH}-java")

--- a/init/Dockerfile
+++ b/init/Dockerfile
@@ -1,5 +1,4 @@
-FROM bitnami/minideb:stretch
+FROM bitnami/java:1.8-prod
 ENV JAVA_OPTS=""
-ADD build/graal/kees-init-linux-x86_64 /kees-init
-RUN chmod +x /kees-init
-CMD exec /kees-init $JAVA_OPTS
+ADD build/distributions/init.tar /app/
+CMD ["/app/init/bin/init"]

--- a/init/Dockerfile.native
+++ b/init/Dockerfile.native
@@ -1,0 +1,5 @@
+FROM bitnami/minideb:stretch
+ENV JAVA_OPTS=""
+ADD build/graal/kees-init-linux-x86_64 /kees-init
+RUN chmod +x /kees-init
+CMD exec /kees-init $JAVA_OPTS

--- a/init/build.gradle
+++ b/init/build.gradle
@@ -19,6 +19,7 @@ repositories {
 apply plugin: 'java'
 apply plugin: 'maven'
 apply plugin: 'maven-publish'
+apply plugin: 'application'
 apply plugin: com.palantir.gradle.graal.GradleGraalPlugin
 apply plugin: com.google.gradle.osdetector.OsDetectorPlugin
 
@@ -27,6 +28,10 @@ targetCompatibility = 1.8
 group = 'com.bsycorp.kees'
 if (findProperty("appVersion") != null){
     version = findProperty("appVersion")
+}
+
+application {
+    mainClass = 'com.bsycorp.kees.InitMain'
 }
 
 dependencies {


### PR DESCRIPTION
The java version will be pushed to Docker tag like: 0.1.25-java.

Init is available as native or java, currently creator is java version only for e.g. 0.1.25 and 0.1.25-java.
